### PR TITLE
Handled empty string upload_metadata

### DIFF
--- a/tusserver/tus.py
+++ b/tusserver/tus.py
@@ -99,7 +99,7 @@ def create_api_router(files_dir='/tmp/files', location='http://127.0.0.1:8000/fi
 
         # Create a new upload and store the file and metadata in the mapping
         metadata = {}
-        if upload_metadata is not None:
+        if upload_metadata is not None and upload_metadata != '':
             # Decode the base64-encoded string
             for kv in upload_metadata.split(","):
                 key, value = kv.rsplit(" ", 1)


### PR DESCRIPTION
With tuspy 1.0.0 and tuspyserver 1.2.0 release, the upload_metadata is passed as "" (an empty string) which is not handled by `if upload_metadata is not None:` causing an exception on line 116 for the file tus.py