### PR TITLE
Add metadata to upload complete callback

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,9 +14,10 @@ app.add_middleware(
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
-def on_upload_complete(file_path: str):
+def on_upload_complete(file_path: str, metadata: dict):
     print('Upload complete')
     print(file_path)
+    print(metadata)
 
 
 def on_your_specific_auth():

--- a/tusserver/tus.py
+++ b/tusserver/tus.py
@@ -15,7 +15,7 @@ def create_api_router(
         files_dir='/tmp/files',
         location='http://127.0.0.1:8000/files',
         max_size=128849018880,
-        on_upload_complete: Optional[Callable[[str], None]] = None,
+        on_upload_complete: Optional[Callable[[str, dict], None]] = None,
         auth: Optional[Callable[[], None]] = None,
         days_to_keep: int = 5,
 ):
@@ -273,7 +273,7 @@ def create_api_router(
             response.headers["Upload-Expires"] = str(meta.expires)
             response.status_code = status.HTTP_204_NO_CONTENT
             if on_upload_complete:
-                on_upload_complete(os.path.join(files_dir, f'{uuid}'))
+                on_upload_complete(os.path.join(files_dir, f'{uuid}'), meta.metadata)
 
             return response
 


### PR DESCRIPTION
Hi,

And thanks for providing this package. For me it makes sense to have access to the metadata of the file when doing post processing of the file upload. Is this something you would consider adding to the package?

Thanks in advance!